### PR TITLE
Implement ~70x Speed Increase for Encryption

### DIFF
--- a/gaillier_test.go
+++ b/gaillier_test.go
@@ -149,3 +149,16 @@ func TestMul(t *testing.T) {
 		t.Errorf("Error Mul function want %d , got %d", corr, result)
 	}
 }
+
+func BenchmarkEncrypt(b *testing.B) {
+	pubKey, _, _ := GenerateKeyPair(rand.Reader, 2048)
+	val := new(big.Int).SetInt64(int64(1234)).Bytes()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, err := Encrypt(pubKey, val)
+		if err != nil {
+			b.Fail()
+		}
+	}
+}


### PR DESCRIPTION
As noted in issue #2 only a coprime `r` is needed when Encrypting because `r` is defined to be: 

<img src="https://render.githubusercontent.com/render/math?math=0%20%3C%20r%20%3C%20n\%20\mathrm{and}\%20%20r%20\in%20Z_{n}^{*}"/>

Which means that `r` must be in the set of integers that is coprime to `n`. Because `n = p*q`, this is actually super easy to do. We can randomly generate an `r` and then check that `gcd(n, r) = 1`. This will usually just go through 1 cycle because it is extremely unlikely that the generated `r` is actually `p`, `q` or a constant multiple thereof.

## Performance Improvements
Encrypt is nearly 2 orders of magnitude faster after this optimization. I wrote a small benchmark to demonstrate this:

### Before ~727ms
```
BenchmarkEncrypt
BenchmarkEncrypt-16    	       2	 727487778 ns/op
```

### After ~11ms
```
BenchmarkEncrypt
BenchmarkEncrypt-16    	     100	  11200899 ns/op
```